### PR TITLE
fix #49 expressにtrust proxyオプションを付与

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -44,6 +44,7 @@ app.middleware('parse', bodyParser.urlencoded({
   extended: true,
 }));
 
+app.set('trust proxy', 1);
 app.middleware('session:before', cookieParser(app.get('cookieSecret')));
 app.middleware('session', session({
   secret: app.get('sessionSecret'),


### PR DESCRIPTION
app.enable('trust proxy');